### PR TITLE
[OwnerManagement] Use replies in sending confirmation messages.

### DIFF
--- a/ownermanagement/ownermanagement.py
+++ b/ownermanagement/ownermanagement.py
@@ -37,7 +37,7 @@ class OwnerManagement(commands.Cog):
         self.bot.owner_ids.add(user.id)
         await ctx.tick()
         msg=f"{user} is now a bot owner. Do note that this user currently **has access to everything on the bot, including being able to remove your ownership from the bot.** If you've done this by mistake, please do `{ctx.prefix}owner remove {user.id}` Owners set with this command don't persist during restart. To have a more permanent option, use `redbot instancename --owner {ctx.author.id} --co-owner {user.id}`"
-        await ctx.send(msg)
+        await ctx.send(msg, reference=ctx.message.to_reference()
 
     @owner.command(invoke_without_command="True")
     @commands.is_owner()
@@ -48,9 +48,9 @@ class OwnerManagement(commands.Cog):
         remmsg=f"{user} is no longer a bot owner."
         getoutmsg=f"{user} is a default owner, and cannot be removed."
         if user.id in self.default_owners:
-            await ctx.send(getoutmsg)
+            await ctx.send(getoutmsg, reference=ctx.message.to_reference()
         else:
             self.bot.owner_ids.remove(user.id)
             await ctx.tick()
-            await ctx.send(remmsg)
+            await ctx.send(remmsg, reference=ctx.message.to_reference()
         


### PR DESCRIPTION
## Description of changes
Use ctx.message.to_reference() for sending messages, to make the bot to reply to the command invoker.